### PR TITLE
Improve return type, tweak options

### DIFF
--- a/dist/eru.d.ts
+++ b/dist/eru.d.ts
@@ -1,11 +1,11 @@
 interface EruListeners {
-    error?: (type: Request['method'], e: Error) => void;
-    loading?: (type: Request['method'], isLoading: boolean) => void;
+    onError?: (error: Error, type: Request['method']) => void;
+    onLoading?: (isLoading: boolean, type: Request['method']) => void;
 }
-interface EruConfig extends RequestInit {
+interface EruConfig extends RequestInit, EruListeners {
     rootPath?: string;
     authTokenKey?: string;
-    on?: EruListeners;
+    rejectDefault?: any;
 }
 export declare const cfg: EruConfig;
 export declare function setupEru(config: EruConfig): void;
@@ -21,10 +21,10 @@ interface RequestConfig<OptionalBodyType = string | object> extends Omit<EruConf
  * @returns
  */
 export declare function eru(path: string, options?: EruConfig): {
-    get: <T>(id?: string | number | Omit<RequestConfig, 'body'>, options?: RequestConfig) => Promise<Error | T>;
-    delete: <T_1>(id: number, options?: Omit<RequestConfig, 'body'>) => Promise<Error | T_1>;
-    post: <T_2>(options: RequestConfig<T_2>) => Promise<Error | T_2>;
-    put: <T_3>(id: string | number, options: RequestConfig<T_3>) => Promise<Error | T_3>;
-    patch: <T_4>(id: string | number, options: RequestConfig<T_4>) => Promise<Error | T_4>;
+    get: <T>(id?: string | number | Omit<RequestConfig, 'body'>, options?: RequestConfig) => Promise<T>;
+    delete: <T_1>(id: number, options?: Omit<RequestConfig, 'body'>) => Promise<T_1>;
+    post: <T_2>(options: RequestConfig<T_2>) => Promise<T_2>;
+    put: <T_3>(id: string | number, options: RequestConfig<T_3>) => Promise<T_3>;
+    patch: <T_4>(id: string | number, options: RequestConfig<T_4>) => Promise<T_4>;
 };
 export {};

--- a/dist/eru.js
+++ b/dist/eru.js
@@ -1,10 +1,10 @@
-function s(t) {
-  if (!t)
+function g(a) {
+  if (!a)
     return "";
-  const r = Object.keys(t).map((a) => [a, t[a]].map(encodeURIComponent).join("=")).join("&");
-  return r ? `?${r}` : "";
+  const e = Object.keys(a).map((c) => [c, a[c]].map(encodeURIComponent).join("=")).join("&");
+  return e ? `?${e}` : "";
 }
-const u = {
+const n = {
   mode: "cors",
   rootPath: "",
   authTokenKey: void 0,
@@ -13,66 +13,67 @@ const u = {
     "Content-Type": "application/json"
   }
 };
-function b(t) {
-  Object.assign(u, t);
+function O(a) {
+  Object.assign(n, a);
 }
-async function m(t, r) {
-  var a;
-  return u.authTokenKey && (r.headers.Authorization = `Bearer ${localStorage.getItem(u == null ? void 0 : u.authTokenKey)}`), (a = r.on) != null && a.loading && r.on.loading(r.method, !0), r.body && (r.body = JSON.stringify(r.body)), fetch(r.rootPath + t, r).then(async (e) => e.text().then((n) => {
-    var y, h;
-    if (!e.ok) {
-      let d = null;
-      try {
-        d = JSON.parse(n).message;
-      } catch {
-        d = n;
-      }
-      const l = new Error(d || `An unexpected error occured: ${e.statusText}`);
-      return (y = r == null ? void 0 : r.on) != null && y.error && ((h = r.on) == null || h.error(r.method, l)), Promise.reject(l);
-    }
-    let c;
-    try {
-      c = JSON.parse(n);
-    } catch {
-      c = n;
-    }
-    return c;
-  })).catch((e) => {
-    var n, c;
-    return (n = r == null ? void 0 : r.on) != null && n.error && ((c = r.on) == null || c.error(r.method, e)), e;
-  }).finally(() => {
-    var e, n;
-    (e = r.on) != null && e.loading && ((n = r.on) == null || n.loading(r.method, !1));
+async function m(a, e) {
+  return n.authTokenKey && (e.headers.Authorization = `Bearer ${localStorage.getItem(n == null ? void 0 : n.authTokenKey)}`), e.onLoading && e.onLoading(!0, e.method), e.body && (e.body = JSON.stringify(e.body)), new Promise((c, r) => {
+    fetch(e.rootPath + a, e).then((t) => {
+      t.text().then((u) => {
+        if (!t.ok) {
+          n.rejectDefault && c(n.rejectDefault);
+          let y = null;
+          try {
+            y = JSON.parse(u).message;
+          } catch {
+            y = u;
+          }
+          const h = new Error(y || `[${t.status}] ${t.statusText}`);
+          e != null && e.onError && e.onError(h, e.method), r(h);
+        }
+        let f;
+        try {
+          f = JSON.parse(u);
+        } catch {
+          f = u;
+        }
+        c(f);
+      });
+    }).catch((t) => {
+      e != null && e.onError && e.onError(t, e.method), n.rejectDefault ? c(n.rejectDefault) : r(t);
+    }).finally(() => {
+      e.onLoading && e.onLoading(!1, e.method);
+    });
   });
 }
-function g(t, r, a, e, n) {
-  const c = Object.assign(u, n, {
-    method: t,
-    body: JSON.stringify(e.body)
-  }, e);
-  return m(`${r}/${a}${s(e == null ? void 0 : e.query)}`, c);
+function l(a, e, c, r, t) {
+  const u = Object.assign(n, t, {
+    method: a,
+    body: JSON.stringify(r.body)
+  }, r);
+  return m(`${e}/${c}${g(r == null ? void 0 : r.query)}`, u);
 }
-function f(t, r, a, e, n) {
-  const c = Object.assign(u, n, {
-    method: t
-  }, e);
-  return m(r + a + s(e == null ? void 0 : e.query), c);
+function d(a, e, c, r, t) {
+  const u = Object.assign(n, t, {
+    method: a
+  }, r);
+  return m(e + c + g(r == null ? void 0 : r.query), u);
 }
-function T(t, r) {
-  const a = r ?? {};
+function b(a, e) {
+  const c = e ?? {};
   return {
-    get: (e, n) => {
-      const c = typeof e == "number" || typeof e == "string" ? `/${e}` : "";
-      return f("GET", t, c, typeof e == "number" || typeof e == "string" ? n : e, a);
+    get: (r, t) => {
+      const u = typeof r == "number" || typeof r == "string" ? `/${r}` : "";
+      return d("GET", a, u, typeof r == "number" || typeof r == "string" ? t : r, c);
     },
-    delete: (e, n) => f("DELETE", t, e, n, a),
-    post: (e) => f("POST", t, "", e, a),
-    put: (e, n) => g("PUT", t, e, n, a),
-    patch: (e, n) => g("PATCH", t, e, n, a)
+    delete: (r, t) => d("DELETE", a, r, t, c),
+    post: (r) => d("POST", a, "", r, c),
+    put: (r, t) => l("PUT", a, r, t, c),
+    patch: (r, t) => l("PATCH", a, r, t, c)
   };
 }
 export {
-  u as cfg,
-  T as eru,
-  b as setupEru
+  n as cfg,
+  b as eru,
+  O as setupEru
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "eru-src",
-  "version": "0.0.0",
+  "name": "eru",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "eru-src",
-      "version": "0.0.0",
+      "name": "eru",
+      "version": "0.0.1",
+      "license": "GPL-3.0",
       "devDependencies": {
         "@antfu/eslint-config": "^0.39.1",
         "eslint": "^8.41.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "eru",
+  "name": "@dolanske/eru",
   "type": "module",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "private": true,
-  "description": "Opinionated & configurable wrapper around the fetch API ",
+  "description": "Simple & opinionated wrapper around the Fetch API",
   "author": "dolanske",
   "license": "GPL-3.0",
   "repository": {

--- a/src/eru.ts
+++ b/src/eru.ts
@@ -113,58 +113,6 @@ async function handle<T>(path: string, options: SerializedEruOptions): Promise<T
           options.onLoading(false, options.method)
       })
   })
-
-  // return fetch(options.rootPath + path, options)
-  //   .then(async (res) => {
-  //     return new Promise<T>((resolve, reject) => {
-  //       res.text().then((text: string) => {
-  //         // If something went wrong, we want to either get the error message from the request
-  //         // Or we add a generic error message if it is missing
-  //         if (!res.ok) {
-  //           let message = null
-
-  //           try {
-  //             const parsed = JSON.parse(text)
-  //             message = parsed.message
-  //           }
-  //           catch (e) {
-  //             message = text
-  //           }
-
-  //           const err = new Error(message || `[${res.status}] ${res.statusText}`)
-
-  //           if (options?.on?.error)
-  //             options.on?.error(options.method, err)
-
-  //           reject(err)
-  //         }
-
-  //         // If everything went fine, we still want to check what type was returned
-  //         // API does not always return JSON
-  //         let okRes
-
-  //         try {
-  //           okRes = JSON.parse(text)
-  //         }
-  //         catch (e) {
-  //           // This will only catch if the response is not a JSON, meaning we are returning a string
-  //           okRes = text
-  //         }
-
-  //         resolve(okRes)
-  //       })
-  //     })
-  //   })
-  //   .catch((err) => {
-  //     if (options?.on?.error)
-  //       options.on?.error(options.method, err)
-
-  //     return err
-  //   })
-  //   .finally(() => {
-  //     if (options.on?.loading)
-  //       options.on?.loading(options.method, false)
-  //   })
 }
 
 // Helper method for seting up PUT, PATCH and POST requests as their functionality is exactly the same

--- a/src/eru.ts
+++ b/src/eru.ts
@@ -43,7 +43,7 @@ interface SerializedEruOptions extends EruConfig {
   method: Request['method']
 }
 
-async function handle<T>(path: string, options: SerializedEruOptions): Promise<T | Error> {
+async function handle<T>(path: string, options: SerializedEruOptions): Promise<T> {
   if (cfg.authTokenKey)
     // @ts-expect-error options.headers are defined in the `cfg` defaults, which indeed are merged together in the patch functions
     options.headers.Authorization = `Bearer ${localStorage.getItem(cfg?.authTokenKey)}`

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,23 +1,4 @@
-import { eru, setupEru } from './eru'
+// Test during implementation here
+export function noop() {
 
-setupEru({
-  rootPath: 'https://swapi.dev/api',
-  rejectDefault: [],
-})
-
-const test = eru('/cum')
-
-interface Result {
-  count: number
 }
-
-test.get<Result[]>({
-  rejectDefault: [],
-  onLoading: state => console.log(state),
-
-})
-  .then((result) => {
-    console.log(result)
-  })
-
-const result = fetch('/test')

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,22 +1,23 @@
-import { eru } from './eru'
+import { eru, setupEru } from './eru'
 
-const test = eru('/')
-
-interface User {
-  name: string
-  age?: number
-}
-
-const { signal, abort } = new AbortController()
-
-test.post<User>({
-  body: {
-    name: 'Bello',
-    age: 10,
-  },
-  signal,
+setupEru({
+  rootPath: 'https://swapi.dev/api',
+  rejectDefault: [],
 })
 
-setTimeout(() => {
-  abort()
-}, 10)
+const test = eru('/cum')
+
+interface Result {
+  count: number
+}
+
+test.get<Result[]>({
+  rejectDefault: [],
+  onLoading: state => console.log(state),
+
+})
+  .then((result) => {
+    console.log(result)
+  })
+
+const result = fetch('/test')


### PR DESCRIPTION
This PR fixes an issue where return type could be `T | Error`. This unfortunately is impossible to type in the current implentation. It is impossible to separately type response within `.then()` and `.catch()`. So it now returns unknown or the user provided type.

Promise rejection has been fixed too. Previously it'd return an error in `.then()` instead of actually jumping to `.catch()`.

Added new option `rejectDefault: any` which can be added as an option whenever in the chain. What it does, when an error occurs, instead of the return object being the error, it will return `rejectDefault` value instead. It will still call `.catch()`.

```ts
const res = api.get<Users[]>('/test/', { rejectDefault: [] })
```
In this example, without default data, the returned type would be `User[]` but the value would be an `Error` object. This can be prevented by using the following:

```ts 
const res = api.get<Users[]>('/test/')
  .catch(() => [])
```

But... that's exactly what the `rejectDefault` option is for.